### PR TITLE
fix: Dockerfile go buildvcs=false

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.18-bullseye as build
 
 WORKDIR /root/app
 COPY . .
-RUN go build -ldflags="-s -w" -o autoagora-indexer-service ./src
+RUN go build -buildvcs=false -ldflags="-s -w" -o autoagora-indexer-service ./src
 
 ########################################################################################
 


### PR DESCRIPTION
Turn off go build's VCS tagging in the Dockerfile, as it can cause issues in certain scenarios, such as when this repo is cloned as a git submodule.

fixes #1 