### PR TITLE
ci(dco-check): updated workflow to exclude depedabot generic emails

### DIFF
--- a/.github/workflows/dco_check.yml
+++ b/.github/workflows/dco_check.yml
@@ -24,9 +24,10 @@ jobs:
       - name: Check DCO
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DCO_CHECK_EXCLUDE_PATTERN: dependabot\[bot\]@users\.noreply\.github\.com
           DCO_CHECK_VERBOSE: '1'
           # Comma-separated list of emails that should be ignored during DCO checks
           # DCO_CHECK_EXCLUDE_EMAILS: ${{ inputs.exclude-emails }}
         run: |
-          pip3 install -U git+https://github.com/aasseman/dco-check.git@pull_request_target_support
+          pip3 install -U dco-check
           dco-check


### PR DESCRIPTION
Signed-off-by: Tümay Tuzcu <tumay@semiotic.ai>